### PR TITLE
Check Qt5 version is high enough to build project (>= 5.14.0)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,15 @@ endif()
 
 option(UNITY_BUILD "Perform a unity build" OFF)
 
+find_package(Qt5Widgets REQUIRED)
+if (Qt5Widgets_FOUND)
+    if (Qt5Widgets_VERSION VERSION_LESS 5.14.0)
+        message(FATAL_ERROR "Minimum supported Qt5 version is 5.14!")
+    endif()
+else()
+    message(SEND_ERROR "The Qt5Widgets library could not be found!")
+endif(Qt5Widgets_FOUND)
+
 include_directories(source)
 
 add_subdirectory(source/thirdparty)


### PR DESCRIPTION
This checks the Qt version in root CMakeLists.txt file.

Version determined by minimum version for QDate::startOfDay() which is introduced in 5.14